### PR TITLE
Fix some errors 

### DIFF
--- a/apps/finder.py
+++ b/apps/finder.py
@@ -2,9 +2,9 @@ from talon.voice import Key, Context, Str, press
 
 def go_to_path(path):
     def path_function(m):
-    press('cmd-shift-g')
-    Str(path)(None)
-    press('return')
+        press('cmd-shift-g')
+        Str(path)(None)
+        press('return')
     return path_function
 
 ctx = Context('Finder', bundle='com.apple.finder')

--- a/misc/menu.py
+++ b/misc/menu.py
@@ -41,7 +41,10 @@ set {text item delimiters, TID} to {",", text item delimiters}
 set {text item delimiters, theListAsString} to {TID, theList as text}
 return theListAsString
 ''')
-    items = items.split(',')
+    if items is not None:
+        items = items.split(',')
+    else:
+        items = []
     new = {}
     for item in items:
         words = item.split(' ')


### PR DESCRIPTION
On load, I saw some errors come up:
* missing indentation in `apps/finder.py`
* NoneType has no `split` method `misc/menu.py`

