### PR TITLE
Remove 'up' due to false positives.

### DIFF
--- a/misc/navigation.py
+++ b/misc/navigation.py
@@ -37,7 +37,7 @@ keymap = {
     "lefty": Key("cmd-left"),
     "crimp": Key("left"),
     "chris": Key("right"),
-    "(up | jeep)": Key("up"),
+    "jeep": Key("up"),
     "(down | dune | doom)": Key("down"),
     "scroll down": [Key("down")] * 30,
     "(doomway | scroll way down)": Key("cmd-down"),


### PR DESCRIPTION
In the official examples, `up` has to be prefixed by `go` or a modifier in order to take because it often results in false positives (for me, `odd` often resolves to `up`).

I'm proposing its definitive removal. I kind of think `down` should be removed too, but one thing at a time.