### PR TITLE
Fix sentences (and comma clauses).

### DIFF
--- a/misc/std.py
+++ b/misc/std.py
@@ -5,7 +5,7 @@ from talon import ctrl, clip
 from talon_init import TALON_HOME, TALON_PLUGINS, TALON_USER
 import string
 
-from ..utils import parse_word, surround, text, sentence_text, word, parse_words
+from ..utils import parse_word, surround, text, sentence_text, word, parse_words, spoken_text
 from .basic_keys import alpha_alt
 
 
@@ -89,7 +89,7 @@ ctx.keymap(
     {
         "phrase <dgndictation> [over]": text,
         "sentence <dgndictation> [over]": sentence_text,
-        "comma <dgndictation> [over]": [", ", text],
+        "comma <dgndictation> [over]": [", ", spoken_text],
         "period <dgndictation> [over]": [". ", sentence_text],
         # "more <dgndictation> [over]": [" ", text],
         "word <dgnwords>": word,

--- a/utils.py
+++ b/utils.py
@@ -131,8 +131,10 @@ for k, v in mapping.items():
 punctuation = set(".,-!?")
 
 
-def parse_word(word):
-    word = str(word).lstrip("\\").split("\\", 1)[0].lower()
+def parse_word(word, force_lowercase=True):
+    word = str(word).lstrip("\\").split("\\", 1)[0]
+    if force_lowercase:
+        word = word.lower()
     word = mapping.get(word, word)
     return word
 
@@ -157,7 +159,7 @@ def replace_words(words, mapping, count):
     return new_words
 
 
-def parse_words(m):
+def parse_words(m, natural=False):
     if isinstance(m, list):
         words = m
     elif hasattr(m, 'dgndictation'):
@@ -165,7 +167,7 @@ def parse_words(m):
     else:
         return []
 
-    words = list(map(parse_word, words))
+    words = list(map(lambda current_word: parse_word(current_word, not natural), words))
     words = replace_words(words, mappings[2], 2)
     words = replace_words(words, mappings[3], 3)
     return words
@@ -188,9 +190,14 @@ def text(m):
     insert(join_words(parse_words(m)).lower())
 
 
+def spoken_text(m):
+    insert(join_words(parse_words(m, True)))
+
+
 def sentence_text(m):
-    text = join_words(parse_words(m)).lower()
-    insert(text.capitalize())
+    raw_sentence = join_words(parse_words(m, True))
+    sentence = raw_sentence[0].upper() + raw_sentence[1:]
+    insert(sentence)
 
 
 def word(m):


### PR DESCRIPTION
This attempts to improve the functionality of the `sentence` command. It stops lowercasing words that probably shouldn't be in lowercase in the context of a spoken sentence.

Feedback welcome.