### PR TITLE
Add hold to mute script

### DIFF
--- a/misc/mute.py
+++ b/misc/mute.py
@@ -10,6 +10,9 @@ The intended use cases include:
 
 Notes:
 
+- Due to this script using the same mechanism to disable the microphone as the
+  misc/speech_toggle.py script, you can press and release the TRIGGER_KEY to
+  enable the microphone rather than saying "Talon wake".
 - At the moment, it does not disable the microphone in Dragon so if the
   microphone is awake, you must put it to sleep by saying "Go to sleep".
 - There is a bug in Talon which means the microphone will not be re-enabled if

--- a/misc/mute.py
+++ b/misc/mute.py
@@ -1,0 +1,22 @@
+from talon import tap
+from talon_plugins import speech
+from talon import voice
+
+# Hold this key down to disable talon
+TRIGGER_KEY = 'shift-ctrl-a'
+
+
+def on_key(typ, e):
+    if e != TRIGGER_KEY:
+        return
+
+    e.block()
+
+    should_be_enabled = e.up
+    if voice.talon.enabled == should_be_enabled:
+        return
+
+    speech.set_enabled(should_be_enabled)
+
+
+tap.register(tap.KEY | tap.HOOK, on_key)

--- a/misc/mute.py
+++ b/misc/mute.py
@@ -12,6 +12,10 @@ Notes:
 
 - At the moment, it does not disable the microphone in Dragon so if the
   microphone is awake, you must put it to sleep by saying "Go to sleep".
+- There is a bug in Talon which means the microphone will not be re-enabled if
+  you release the modifier keys before the main key in TRIGGER_KEY
+  https://github.com/talonvoice/talon/issues/83 (this comment was added on
+  Feburary 5, 2019)
 '''
 
 from talon import tap

--- a/misc/mute.py
+++ b/misc/mute.py
@@ -1,3 +1,19 @@
+'''
+This script provides a quick way for disabling and re-enabling Talon.
+
+The intended use cases include:
+
+- Someone starts talking to you and you want to quickly disable the microphone
+  to prevent random commands from being run
+- You are working with someone, and so are switching between talking to them
+  and dictating talon commands (e.g. by pair programming on your computer).
+
+Notes:
+
+- At the moment, it does not disable the microphone in Dragon so if the
+  microphone is awake, you must put it to sleep by saying "Go to sleep".
+'''
+
 from talon import tap
 from talon_plugins import speech
 from talon import voice


### PR DESCRIPTION
I thought I would try adding a use cases/description section to the top of the script to help people understand what exactly this script is useful for, given this is in the misc folder. I would be keen to hear of your opinions on this

I haven't tested this that thoroughly, or used it in those particular use cases enough to say how useful it is, but I will be using it occasionally over the next few weeks, and we will see how it goes from there.

Just another note, I decided to make this a hold-to-mute rather than a press-to-toggle script because you can easily forget whether the microphone is enabled or not. This makes it easier for the user to reliably use the script for the intended use case.

I'm not quite sure about the specific TRIGGER_KEY, but I found that it hasn't conflicted with anything so far. The only thing I can think of it conflicting with is if someone is using Windows or Linux inside a virtual machine inside the Mac. I chose it because it is convenient my keyboard, but then again I have remapped CapsLock to control. I am open to any other suggestions for alternative TRIGGER_KEY

