### PR TITLE
Added common shortcuts on Mac OS X. 

### DIFF
--- a/misc/mac_os_x.py
+++ b/misc/mac_os_x.py
@@ -1,0 +1,20 @@
+from talon.voice import Context, press, Key
+
+ctx = Context("mac_os_x")
+ctx.keymap(
+    {
+        "cut": Key("cmd-x"),
+        "copy": Key("cmd-c"),
+        "paste": Key("cmd-v"),
+        "(next tab | goneck)": Key("cmd-shift-]"),
+        "((last | previous | preev) tab | gopreev)": Key("cmd-shift-["),
+        "undo": Key("cmd-z"),
+        "redo": Key("cmd-shift-z"),
+        "new tab": Key("cmd-t"),
+        "close": Key("cmd-w"),
+        "close all tabs": Key("cmd-shift-w"),
+        "(view|pick) (emojis|symbols)": Key("ctrl-cmd-space"),
+        "force quit": Key("cmd-option-esc"),
+        "preferences": Key("cmd-,")
+    }
+)


### PR DESCRIPTION
Some of these are defined similarly in specific apps (e.g. Chrome), but these should work across all apps.

Most taken from [Apple's Mac keyboard shortcuts](https://support.apple.com/en-us/HT201236). Tab navigation taken from [Safari shortcuts doc](https://support.apple.com/guide/safari/keyboard-and-other-shortcuts-cpsh003/mac) but are fairly standard across Mac OS X apps (e.g. also work for Terminal and Finder).
