### PR TITLE
Removes the format option: `index`

### DIFF
--- a/text/formatters.py
+++ b/text/formatters.py
@@ -67,7 +67,7 @@ surrounders = normalise_keys(
         "padded": (False, surround(" ")),
         "dunder": (False, surround("__")),
         "angler": (False, surround("<", ">")),
-        "(index | brax)": (False, surround("[", "]")),
+        "brax": (False, surround("[", "]")),
         "kirk": (False, surround("{", "}")),
         "precoif": (False, surround('("', '")')),
         "(prex | args)": (False, surround("(", ")")),


### PR DESCRIPTION
`index` is problematic in many instances for example:

  `['a', 'b', 'c'].each_with_index { |letter, index| puts "#{index}: #{letter}" }`

  Currently trying to say: `snake each with index` outputs: `each_with[]`