### PR TITLE
Update switcher.py

### DIFF
--- a/misc/switcher.py
+++ b/misc/switcher.py
@@ -71,7 +71,7 @@ def update_lists():
     ctx.set_list("running", running.keys())
 
     new = {}
-    for base in "/Applications", "/Applications/Utilities":
+    for base in "/Applications", "/Applications/Utilities","/System/Applications","/System/Applications/Utilities":
         for name in os.listdir(base):
             path = os.path.join(base, name)
             name = name.rsplit(".", 1)[0]


### PR DESCRIPTION
In OSX Catalina (15.4) they have moved several apps to "/System/Applications/". Launch commands don't seem to work without changing line 74 accordingly.